### PR TITLE
Refresh the Chairs list for the OSPO WG

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,16 @@ See the [CONTRIBUTING.md](CONTRIBUTING.md) for more information.
 
 ### Chairs
 
+- [Gary White](https://github.com/garypwhite)
+- [Dawn Foster](https://github.com/geekygirldawn)
+
+Please feel free to contact our chairs in case you require any sort of assistance.
+
+### Maintainers
+
 - [Vinod Ahuja](https://github.com/vinodkahuja)
 - [Sean Goggins](https://github.com/sgoggins)
 - [Ana Jiménez](https://github.com/anajsana)
-
- Please feel free to contact our chairs in case you require any sort of assistance.
 
 ### Amazing CHAOSS Project Contributors
 


### PR DESCRIPTION
Refresh the Chairs list for the OSPO WG so that we have someone working in an OSPO as one of the chairs (Gary) and to reflect the reality of how we've been operating as a WG with me leading most of the meetings. 

Moved the previous chairs to the Maintainers list (with their consent), since they all continue to be involve in the WG.